### PR TITLE
Fix typo: 2002>2020

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can find him as @ahmetb on Twitter and GitHub.
 
 **Using Kubernetes to Build Better Kubernetes Networking and Autoscaling** – KubeCon/CloudNativeCon 2020 EU @ Amsterdam, Netherlands
 
-- (Upcoming, currently postponed to August 2002 due to COVID-19 outbreak)
+- (Upcoming, currently postponed to August 2020 due to COVID-19 outbreak)
 - [Description](https://kccnceu20.sched.com/event/ZeoM)
 
 **Using Serverless on Kubernetes with Cloud Run** @ Google Cloud Turkey, Istanbul, Turkey (Webinar)


### PR DESCRIPTION
On the [homepage](https://github.com/ahmetb/public-speaking) there was a typo in this sentence:

>(Upcoming, currently postponed to August **2002** due to COVID-19 outbreak)

Which should probable be instead:

>(Upcoming, currently postponed to August **2020** due to COVID-19 outbreak)